### PR TITLE
fix a typo (I think). Thanks for the report!

### DIFF
--- a/reports/variant_report_latest_draft.md
+++ b/reports/variant_report_latest_draft.md
@@ -12,10 +12,10 @@ Nowcasting haplotype prevalence (using the logistic fit from covSpectrum), S:346
 
 Both mutations together currently appear in around 15% of all BQ.1\* globally. The relative growth advantage of this haplotype compared to all BQ.1\* is around 5% per day which corresponds to a doubling time of around 2 weeks.
 
-Within BQ.1.1, two level 8 lineages have recently been designated but it is too early to say how fast (if at all) they will grow. Both lineages notably lack the S:144- deletion.
+Within BQ.1.1, two level 7 lineages have recently been designated but it is too early to say how fast (if at all) they will grow. Both lineages notably lack the S:144- deletion.
 
 - CZ.1 (aka BQ.1.1.1.1) with extra S:F490I has been sequenced in 4 countries, once each: England, South Korea, Austria and Romania and is predicted to be more immune evasive than BQ.1.1
-- CW.1 (aka BQ.1.1.14) with extra S:G446S has been sequenced 8 times in England
+- CW.1 (aka BQ.1.1.14.1) with extra S:G446S has been sequenced 8 times in England
 
 ## XBB still in the race
 


### PR DESCRIPTION
BQ.1.1.11 and BQ.1.1.12 has 1 additional key RBD mutation beyond the level 6 lineage BQ.1.1, so they should be level 7 lineage.